### PR TITLE
docs(wasm-gol): add how to run readme

### DIFF
--- a/static/wasm-gol/README.md
+++ b/static/wasm-gol/README.md
@@ -1,0 +1,8 @@
+# Game of Life
+
+## How to run
+
+1. `npm install`
+2. Install wasm-pack - https://github.com/wasm-tool/wasm-pack-plugin#wasm-pack (https://rustwasm.github.io/wasm-pack/installer/)
+3. `npm run serve`
+4. open http://localhost:8080/


### PR DESCRIPTION
Hi Nikita. Nice article "First impressions on Rust and Webassembly". But when I tried to run it locally it did not work. So I figured out that additionally to `npm install` I need to install wasm-pack.
So I think it would be useful to add readme :)